### PR TITLE
Refactor scallop lending fetcher

### DIFF
--- a/packages/plugins/src/plugins/scallop/cnyAirdropFetcher.ts
+++ b/packages/plugins/src/plugins/scallop/cnyAirdropFetcher.ts
@@ -4,7 +4,7 @@ import BigNumber from 'bignumber.js';
 import axios, { AxiosResponse } from 'axios';
 import { Cache } from '../../Cache';
 import { Fetcher, FetcherExecutor } from '../../Fetcher';
-import { airdropUrl, platformId, tableId } from './constants';
+import { AIRDROP_URL, platformId, CNY_TABLE_ID } from './constants';
 import { getDynamicFieldObject } from '../../utils/sui/getDynamicFieldObject';
 import { ApiResponse, ClaimStatus } from './types';
 import tokenPriceToAssetToken from '../../utils/misc/tokenPriceToAssetToken';
@@ -28,7 +28,7 @@ function getAmount(claimData: string): number | undefined {
 
 const executor: FetcherExecutor = async (owner: string, cache: Cache) => {
   const signature: AxiosResponse<ApiResponse> | null = await axios
-    .get(airdropUrl + owner)
+    .get(AIRDROP_URL + owner)
     .catch(() => null);
 
   if (!signature?.data.data || signature.status === 404) return [];
@@ -42,7 +42,7 @@ const executor: FetcherExecutor = async (owner: string, cache: Cache) => {
       type: 'address',
       value: owner,
     },
-    parentId: tableId,
+    parentId: CNY_TABLE_ID,
   });
   if (claimStatus.data) return [];
 

--- a/packages/plugins/src/plugins/scallop/constants.ts
+++ b/packages/plugins/src/plugins/scallop/constants.ts
@@ -23,7 +23,10 @@ export const poolsKey = 'scallop-pools-key';
 export const scoinKey = 'scallop-scoin-key';
 export const spoolsKey = 'scallop-spoolsmarket-key';
 
-export const spoolAccountPackageId = `0xe87f1b2d498106a2c61421cec75b7b5c5e348512b0dc263949a0e7a3c256571a::spool_account::SpoolAccount`;
+export const spoolAccountType = `0xe87f1b2d498106a2c61421cec75b7b5c5e348512b0dc263949a0e7a3c256571a::spool_account::SpoolAccount`;
+export const veScaKeyType =
+  '0xcfe2d87aa5712b67cad2732edb6a2201bfdf592377e5c0968b7cb02099bd8e21::ve_sca::VeScaKey';
+  
 const PROTOCOL_OBJECT_ID =
   '0xefe8b36d5b2e43728cc323298626b83177803521d195cfb11e15b910e892fddf';
 export const marketCoinPackageId = `${PROTOCOL_OBJECT_ID}::reserve::MarketCoin`;
@@ -99,44 +102,4 @@ export const sCoinTypesMap = {
     '0x9a2376943f7d22f88087c259c5889925f332ca4347e669dc37d54c2bf651af3c::scallop_ha_sui::SCALLOP_HA_SUI',
   scallop_v_sui:
     '0xe1a1cc6bcf0001a015eab84bcc6713393ce20535f55b8b6f35c142e057a25fbe::scallop_v_sui::SCALLOP_V_SUI',
-} as const;
-
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export type sCoinNames = (typeof SCOIN_NAMES)[number];
-
-export type CoinNames = (typeof COIN_NAMES)[number];
-
-export const sCoinToCoinName: { [T in sCoinNames]: CoinNames } = {
-  scallop_sui: 'sui',
-  scallop_cetus: 'cetus',
-  scallop_sca: 'sca',
-  scallop_wormhole_usdc: 'usdc',
-  scallop_wormhole_usdt: 'usdt',
-  scallop_wormhole_eth: 'eth',
-  scallop_af_sui: 'afsui',
-  scallop_ha_sui: 'hasui',
-  scallop_v_sui: 'vsui',
-};
-
-export type sCoinTypeValue = (typeof sCoinTypesMap)[sCoinNames];
-
-export const sCoinTypeToCoinTypeMap: { [T in sCoinTypeValue]: string } = {
-  [sCoinTypesMap.scallop_sui]:
-    '0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI',
-  [sCoinTypesMap.scallop_cetus]:
-    '0x06864a6f921804860930db6ddbe2e16acdf8504495ea7481637a1c8b9a8fe54b::cetus::CETUS',
-  [sCoinTypesMap.scallop_sca]:
-    '0x7016aae72cfc67f2fadf55769c0a7dd54291a583b63051a5ed71081cce836ac6::sca::SCA',
-  [sCoinTypesMap.scallop_wormhole_usdc]:
-    '0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN',
-  [sCoinTypesMap.scallop_wormhole_usdt]:
-    '0xc060006111016b8a020ad5b33834984a437aaa7d3c74c18e09a95d48aceab08c::coin::COIN',
-  [sCoinTypesMap.scallop_wormhole_eth]:
-    '0xaf8cd5edc19c4512f4259f0bee101a40d41ebed738ade5874359610ef8eeced5::coin::COIN',
-  [sCoinTypesMap.scallop_af_sui]:
-    '0xf325ce1300e8dac124071d3152c5c5ee6174914f8bc2161e88329cf579246efc::afsui::AFSUI',
-  [sCoinTypesMap.scallop_ha_sui]:
-    '0xbde4ba4c2e274a60ce15c1cfff9e5c42e41654ac8b6d906a57efa4bd3c29f47d::hasui::HASUI',
-  [sCoinTypesMap.scallop_v_sui]:
-    '0x549e8b69270defbfafd4f94e17ec44cdbdd99820b33bda2278dea3b9a32d3f55::cert::CERT',
 } as const;

--- a/packages/plugins/src/plugins/scallop/constants.ts
+++ b/packages/plugins/src/plugins/scallop/constants.ts
@@ -80,7 +80,7 @@ export const MARKET_COIN_NAMES = [
   'svsui',
 ] as const;
 
-export const sCoinTypesMap: { [T in sCoinNames]: string } = {
+export const sCoinTypesMap = {
   scallop_sui:
     '0xaafc4f740de0dd0dde642a31148fb94517087052f19afb0f7bed1dc41a50c77b::scallop_sui::SCALLOP_SUI',
   scallop_cetus:
@@ -117,3 +117,26 @@ export const sCoinToCoinName: { [T in sCoinNames]: CoinNames } = {
   scallop_ha_sui: 'hasui',
   scallop_v_sui: 'vsui',
 };
+
+export type sCoinTypeValue = (typeof sCoinTypesMap)[sCoinNames];
+
+export const sCoinTypeToCoinTypeMap: { [T in sCoinTypeValue]: string } = {
+  [sCoinTypesMap.scallop_sui]:
+    '0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI',
+  [sCoinTypesMap.scallop_cetus]:
+    '0x06864a6f921804860930db6ddbe2e16acdf8504495ea7481637a1c8b9a8fe54b::cetus::CETUS',
+  [sCoinTypesMap.scallop_sca]:
+    '0x7016aae72cfc67f2fadf55769c0a7dd54291a583b63051a5ed71081cce836ac6::sca::SCA',
+  [sCoinTypesMap.scallop_wormhole_usdc]:
+    '0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN',
+  [sCoinTypesMap.scallop_wormhole_usdt]:
+    '0xc060006111016b8a020ad5b33834984a437aaa7d3c74c18e09a95d48aceab08c::coin::COIN',
+  [sCoinTypesMap.scallop_wormhole_eth]:
+    '0xaf8cd5edc19c4512f4259f0bee101a40d41ebed738ade5874359610ef8eeced5::coin::COIN',
+  [sCoinTypesMap.scallop_af_sui]:
+    '0xf325ce1300e8dac124071d3152c5c5ee6174914f8bc2161e88329cf579246efc::afsui::AFSUI',
+  [sCoinTypesMap.scallop_ha_sui]:
+    '0xbde4ba4c2e274a60ce15c1cfff9e5c42e41654ac8b6d906a57efa4bd3c29f47d::hasui::HASUI',
+  [sCoinTypesMap.scallop_v_sui]:
+    '0x549e8b69270defbfafd4f94e17ec44cdbdd99820b33bda2278dea3b9a32d3f55::cert::CERT',
+} as const;

--- a/packages/plugins/src/plugins/scallop/constants.ts
+++ b/packages/plugins/src/plugins/scallop/constants.ts
@@ -23,22 +23,23 @@ export const poolsKey = 'scallop-pools-key';
 export const scoinKey = 'scallop-scoin-key';
 export const spoolsKey = 'scallop-spoolsmarket-key';
 
-export const spoolAccountType = `0xe87f1b2d498106a2c61421cec75b7b5c5e348512b0dc263949a0e7a3c256571a::spool_account::SpoolAccount`;
-export const veScaKeyType =
+export const SPOOL_ACCOUNT_TYPE = `0xe87f1b2d498106a2c61421cec75b7b5c5e348512b0dc263949a0e7a3c256571a::spool_account::SpoolAccount`;
+export const VE_SCA_KEY_TYPE =
   '0xcfe2d87aa5712b67cad2732edb6a2201bfdf592377e5c0968b7cb02099bd8e21::ve_sca::VeScaKey';
   
 const PROTOCOL_OBJECT_ID =
   '0xefe8b36d5b2e43728cc323298626b83177803521d195cfb11e15b910e892fddf';
-export const marketCoinPackageId = `${PROTOCOL_OBJECT_ID}::reserve::MarketCoin`;
-export const obligationKeyPackageId = `${PROTOCOL_OBJECT_ID}::obligation::ObligationKey`;
+export const MARKET_COIN_TYPE = `${PROTOCOL_OBJECT_ID}::reserve::MarketCoin`;
+export const OBLIGATION_KEY_TYPE = `${PROTOCOL_OBJECT_ID}::obligation::ObligationKey`;
+
 export const baseIndexRate = 1_000_000_000;
 export const scaAddress =
   '0x7016aae72cfc67f2fadf55769c0a7dd54291a583b63051a5ed71081cce836ac6::sca::SCA';
 export const scaDecimals = 9;
 
-export const tableId =
+export const CNY_TABLE_ID =
   '0xbfbbbdf1fe9b70cdd1ebd1444ca273000177f81a405935f6007b7727d2ff90c2';
-export const airdropUrl =
+export const AIRDROP_URL =
   'https://airdrop.apis.scallop.io/cny-campaign/claim-signature/';
 
 export const SCOIN_NAMES = [
@@ -82,24 +83,3 @@ export const MARKET_COIN_NAMES = [
   'shasui',
   'svsui',
 ] as const;
-
-export const sCoinTypesMap = {
-  scallop_sui:
-    '0xaafc4f740de0dd0dde642a31148fb94517087052f19afb0f7bed1dc41a50c77b::scallop_sui::SCALLOP_SUI',
-  scallop_cetus:
-    '0xea346ce428f91ab007210443efcea5f5cdbbb3aae7e9affc0ca93f9203c31f0c::scallop_cetus::SCALLOP_CETUS',
-  scallop_sca:
-    '0x5ca17430c1d046fae9edeaa8fd76c7b4193a00d764a0ecfa9418d733ad27bc1e::scallop_sca::SCALLOP_SCA',
-  scallop_wormhole_usdc:
-    '0xad4d71551d31092230db1fd482008ea42867dbf27b286e9c70a79d2a6191d58d::scallop_wormhole_usdc::SCALLOP_WORMHOLE_USDC',
-  scallop_wormhole_usdt:
-    '0xe6e5a012ec20a49a3d1d57bd2b67140b96cd4d3400b9d79e541f7bdbab661f95::scallop_wormhole_usdt::SCALLOP_WORMHOLE_USDT',
-  scallop_wormhole_eth:
-    '0x67540ceb850d418679e69f1fb6b2093d6df78a2a699ffc733f7646096d552e9b::scallop_wormhole_eth::SCALLOP_WORMHOLE_ETH',
-  scallop_af_sui:
-    '0x00671b1fa2a124f5be8bdae8b91ee711462c5d9e31bda232e70fd9607b523c88::scallop_af_sui::SCALLOP_AF_SUI',
-  scallop_ha_sui:
-    '0x9a2376943f7d22f88087c259c5889925f332ca4347e669dc37d54c2bf651af3c::scallop_ha_sui::SCALLOP_HA_SUI',
-  scallop_v_sui:
-    '0xe1a1cc6bcf0001a015eab84bcc6713393ce20535f55b8b6f35c142e057a25fbe::scallop_v_sui::SCALLOP_V_SUI',
-} as const;

--- a/packages/plugins/src/plugins/scallop/lendingsFetcher.ts
+++ b/packages/plugins/src/plugins/scallop/lendingsFetcher.ts
@@ -172,10 +172,10 @@ const executor: FetcherExecutor = async (owner: string, cache: Cache) => {
     const parsed = parseStructTag(objType);
     const isCoin = parsed.name === 'Coin';
     const sCoinTypeParsed = parsed.typeParams[0] as StructTag;
-    const isSCoin =
+    const isObjectSCoin =
       !!sCoinToCoinName[sCoinTypeParsed.name.toLowerCase() as sCoinNames];
 
-    return isCoin && isSCoin;
+    return isCoin && isObjectSCoin;
   };
 
   const isMarketCoin = (obj: ObjectResponse<CoinStruct>) => {
@@ -184,11 +184,11 @@ const executor: FetcherExecutor = async (owner: string, cache: Cache) => {
 
     const { address, module, name } = parseStructTag(objType);
     const isCoin = name === 'Coin';
-    const isMarketCoin =
+    const isObjectMarketCoin =
       address === addressData.mainnet.core.object &&
       module === 'reserve' &&
       name === 'MarketCoin';
-    return isCoin && isMarketCoin;
+    return isCoin && isObjectMarketCoin;
   };
 
   allOwnedObjects.forEach((obj: ObjectResponse<any>) => {

--- a/packages/plugins/src/plugins/scallop/lendingsFetcher.ts
+++ b/packages/plugins/src/plugins/scallop/lendingsFetcher.ts
@@ -30,6 +30,8 @@ import {
   scoinPrefix,
   sCoinToCoinName,
   sCoinNames,
+  sCoinTypeToCoinTypeMap,
+  sCoinTypeValue,
 } from './constants';
 import tokenPriceToAssetToken from '../../utils/misc/tokenPriceToAssetToken';
 import {
@@ -184,14 +186,17 @@ const executor: FetcherExecutor = async (owner: string, cache: Cache) => {
       const types = parseStructTag(sCoin.data.type);
       const firstCoin = types.typeParams[0] as unknown as StructTag;
       const coinName = firstCoin.name.toLowerCase() as sCoinNames;
-      const coinType = `${firstCoin.address}::${firstCoin.module}::${firstCoin.name}`;
+      const sCoinType =
+        `${firstCoin.address}::${firstCoin.module}::${firstCoin.name}` as sCoinTypeValue;
+      // need to use the underlying asset type
+      const underlyingCoinType = sCoinTypeToCoinTypeMap[sCoinType];
       const lendingAssetName = sCoinToCoinName[coinName];
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const fields = sCoin.data?.content?.fields as any;
       if (!lendingAssets[lendingAssetName]) {
         lendingAssets[lendingAssetName] = {
           amount: new BigNumber(fields['balance'] ?? 0),
-          coinType,
+          coinType: underlyingCoinType,
         };
       } else {
         lendingAssets[lendingAssetName].amount = lendingAssets[

--- a/packages/plugins/src/plugins/scallop/lendingsFetcher.ts
+++ b/packages/plugins/src/plugins/scallop/lendingsFetcher.ts
@@ -11,15 +11,17 @@ import {
 } from '@sonarwatch/portfolio-core';
 import { normalizeStructTag, parseStructTag } from '@mysten/sui.js/utils';
 import BigNumber from 'bignumber.js';
-import { SuiObjectDataFilter } from '@mysten/sui.js/client';
-import { StructTag } from '@mysten/sui.js/bcs';
+import {
+  CoinMetadata,
+  CoinStruct,
+  SuiObjectDataFilter,
+} from '@mysten/sui.js/client';
 import { Cache } from '../../Cache';
 import { Fetcher, FetcherExecutor } from '../../Fetcher';
 import {
-  marketCoinPackageId,
+  MARKET_COIN_TYPE,
   marketKey,
   platformId,
-  spoolAccountPackageId,
   marketPrefix as prefix,
   poolsKey,
   poolsPrefix,
@@ -28,22 +30,33 @@ import {
   baseIndexRate,
   scoinKey,
   scoinPrefix,
-  sCoinToCoinName,
-  sCoinNames,
-  sCoinTypeToCoinTypeMap,
-  sCoinTypeValue,
+  addressKey,
+  addressPrefix,
+  SPOOL_ACCOUNT_TYPE,
+  MARKET_COIN_NAMES,
 } from './constants';
 import tokenPriceToAssetToken from '../../utils/misc/tokenPriceToAssetToken';
 import {
+  AddressInfo,
+  MarketCoinNames,
   MarketJobResult,
+  PoolCoinNames,
   Pools,
+  sCoinNames,
+  sCoinToCoinName,
   SCoinTypeMetadata,
+  sCoinTypeToCoinTypeMap,
+  sCoinTypeValue,
+  SpoolAccountFieldsType,
   SpoolJobResult,
+  StructTag,
   UserLending,
+  UserLendingData,
   UserStakeAccounts,
 } from './types';
 import { getOwnedObjects } from '../../utils/sui/getOwnedObjects';
 import { getClientSui } from '../../utils/clients';
+import { ObjectData, ObjectResponse } from '../../utils/sui/types';
 
 const executor: FetcherExecutor = async (owner: string, cache: Cache) => {
   const elements: PortfolioElement[] = [];
@@ -67,44 +80,58 @@ const executor: FetcherExecutor = async (owner: string, cache: Cache) => {
   }
 
   const poolValues = Object.values(pools);
-  const sCoinValues = Object.values(sCoins);
   if (poolValues.length === 0) {
     return [];
   }
+
+  const sCoinValues = Object.values(sCoins);
+
+  // {'0x...': CoinMetaData }
+  const poolValuesMetadataMap = poolValues.reduce((acc, poolValue) => {
+    if (poolValue.metadata) acc[poolValue.coinType] = poolValue.metadata;
+    return acc;
+  }, {} as { [k in string]: CoinMetadata });
 
   const client = getClientSui();
   const filterOwnerObject: SuiObjectDataFilter = {
     MatchAny: [
       ...poolValues.map((value) => ({
-        StructType: `0x2::coin::Coin<${marketCoinPackageId}<${value.coinType}>>`,
+        StructType: `0x2::coin::Coin<${MARKET_COIN_TYPE}<${value.coinType}>>`,
       })),
       ...sCoinValues.map(({ coinType }) => ({
         StructType: `0x2::coin::Coin<${coinType}>`,
       })),
       {
-        StructType: spoolAccountPackageId,
+        StructType: SPOOL_ACCOUNT_TYPE,
       },
     ],
   };
 
-  const [allOwnedObjects, marketData, spoolData] = await Promise.all([
-    getOwnedObjects(client, owner, { filter: filterOwnerObject }),
-    cache.getItem<MarketJobResult>(marketKey, {
-      prefix,
-      networkId: NetworkId.sui,
-    }),
-    cache.getItem<SpoolJobResult>(spoolsKey, {
-      prefix: spoolsPrefix,
-      networkId: NetworkId.sui,
-    }),
-  ]);
+  const [allOwnedObjects, marketData, spoolData, addressData] =
+    await Promise.all([
+      getOwnedObjects(client, owner, { filter: filterOwnerObject }),
+      cache.getItem<MarketJobResult>(marketKey, {
+        prefix,
+        networkId: NetworkId.sui,
+      }),
+      cache.getItem<SpoolJobResult>(spoolsKey, {
+        prefix: spoolsPrefix,
+        networkId: NetworkId.sui,
+      }),
+      cache.getItem<AddressInfo>(addressKey, {
+        prefix: addressPrefix,
+        networkId: NetworkId.sui,
+      }),
+    ]);
 
   const fetchedDataIncomplete =
     !marketData ||
     !spoolData ||
+    !addressData ||
     allOwnedObjects.length === 0 ||
     Object.keys(marketData).length === 0 ||
-    Object.keys(spoolData).length === 0;
+    Object.keys(spoolData).length === 0 ||
+    Object.keys(addressData).length === 0;
   if (fetchedDataIncomplete) {
     return [];
   }
@@ -124,107 +151,163 @@ const executor: FetcherExecutor = async (owner: string, cache: Cache) => {
   });
 
   // get user lending assets
-  const lendingAssets: { [key: string]: UserLending } = {};
-  const stakedAccount: UserStakeAccounts = {};
-  for (const ownedMarketCoin of allOwnedObjects) {
-    const objType = ownedMarketCoin.data?.type;
-    if (!objType) continue;
+  const lendingAssets: UserLendingData = {};
+  const stakedAccounts: UserStakeAccounts = {};
+
+  const isSpoolAccount = (obj: ObjectResponse<SpoolAccountFieldsType>) => {
+    const objType = obj.data?.type;
+    if (!objType) return false;
+
+    const { address, module, name } = parseStructTag(
+      normalizeStructTag(objType)
+    );
+
+    return `${address}::${module}::${name}` === SPOOL_ACCOUNT_TYPE;
+  };
+
+  const isSCoin = (obj: ObjectResponse<CoinStruct>) => {
+    const objType = obj.data?.type;
+    if (!objType) return false;
 
     const parsed = parseStructTag(objType);
-    const coinType = normalizeStructTag(
-      objType.substring(
-        objType.indexOf('MarketCoin<') + 11,
-        objType.indexOf('>')
-      )
-    );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const fields = ownedMarketCoin.data?.content?.fields as any;
-    const coinName = poolValues
-      .find((value) => value.coinType === coinType)
-      ?.metadata?.symbol.toLowerCase();
-    if (!coinName || !fields) continue;
-    if (!lendingAssets[coinName]) {
-      lendingAssets[coinName] = { coinType, amount: new BigNumber(0) };
-    }
-    if (fields['stakes']) {
-      if (!stakedAccount[`s${coinName}`]) {
-        stakedAccount[`s${coinName}`] = [];
-      }
-      stakedAccount[`s${coinName}`].push({
-        points: fields['points'],
-        index: fields['index'],
-        stakes: fields['stakes'],
-      });
-    }
-    const balance = BigNumber(
-      (parsed.name === 'Coin' ? fields['balance'] : fields['stakes']) ?? 0
-    );
-    lendingAssets[coinName] = {
-      ...lendingAssets[coinName],
-      amount: lendingAssets[coinName].amount.plus(balance),
-    };
-  }
+    const isCoin = parsed.name === 'Coin';
+    const sCoinTypeParsed = parsed.typeParams[0] as StructTag;
+    const isSCoin =
+      !!sCoinToCoinName[sCoinTypeParsed.name.toLowerCase() as sCoinNames];
 
-  // add support for new sCoin
-  allOwnedObjects
-    .filter((obj) => {
-      const objType = obj.data?.type;
-      if (!objType) return false;
+    return isCoin && isSCoin;
+  };
 
-      const parsed = parseStructTag(objType);
-      const subParsed = parsed.typeParams[0] as unknown as StructTag;
-      if (
-        parsed.name !== 'Coin' ||
-        !sCoinToCoinName[subParsed.name.toLowerCase() as sCoinNames]
-      )
-        return false;
+  const isMarketCoin = (obj: ObjectResponse<CoinStruct>) => {
+    const objType = obj.data?.type;
+    if (!objType) return false;
 
-      return true;
-    })
-    .forEach((sCoin) => {
-      if (!sCoin.data) return;
-      const types = parseStructTag(sCoin.data.type);
-      const firstCoin = types.typeParams[0] as unknown as StructTag;
-      const coinName = firstCoin.name.toLowerCase() as sCoinNames;
-      const sCoinType =
-        `${firstCoin.address}::${firstCoin.module}::${firstCoin.name}` as sCoinTypeValue;
-      // need to use the underlying asset type
-      const underlyingCoinType = sCoinTypeToCoinTypeMap[sCoinType];
-      const lendingAssetName = sCoinToCoinName[coinName];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const fields = sCoin.data?.content?.fields as any;
-      if (!lendingAssets[lendingAssetName]) {
-        lendingAssets[lendingAssetName] = {
-          amount: new BigNumber(fields['balance'] ?? 0),
-          coinType: underlyingCoinType,
-        };
+    const { address, module, name } = parseStructTag(objType);
+    const isCoin = name === 'Coin';
+    const isMarketCoin =
+      address === addressData.mainnet.core.object &&
+      module === 'reserve' &&
+      name === 'MarketCoin';
+    return isCoin && isMarketCoin;
+  };
+
+  allOwnedObjects.forEach((obj: ObjectResponse<any>) => {
+    if (isMarketCoin(obj)) {
+      const marketCoinObj = obj.data as ObjectData<CoinStruct>;
+
+      // access underlying asset type from market coin struct
+      // 0x2::coin::Coin<T>
+      const { address, module, name } = parseStructTag(
+        normalizeStructTag(marketCoinObj.type)
+      ).typeParams[0] as StructTag;
+      const coinType = `${address}::${module}::${name}`;
+      const coinName = poolValuesMetadataMap[
+        coinType
+      ]?.symbol.toLowerCase() as PoolCoinNames;
+      if (!coinName) return;
+
+      const coinBalance = BigNumber(marketCoinObj.content?.fields.balance ?? 0);
+      if (!coinName) return;
+
+      if (lendingAssets[coinName]) {
+        lendingAssets[coinName]!.amount =
+          lendingAssets[coinName]!.amount.plus(coinBalance);
       } else {
-        lendingAssets[lendingAssetName].amount = lendingAssets[
-          lendingAssetName
-        ].amount.plus(new BigNumber(fields['balance'] ?? 0));
+        lendingAssets[coinName] = { coinType, amount: coinBalance };
       }
-    });
+    } else if (isSpoolAccount(obj)) {
+      const spoolObj = obj.data as ObjectData<SpoolAccountFieldsType>;
+      const fields = spoolObj.content?.fields;
+      if (!fields) return;
+
+      // parse market coin struct inside the spoolAccount struct
+      // 0x...::spool_account::SpoolAccount<0x..::reserve::MarketCoin<T>>
+      const marketCoinStruct = parseStructTag(normalizeStructTag(spoolObj.type))
+        .typeParams[0] as StructTag;
+      const { address, module, name } = marketCoinStruct
+        .typeParams[0] as StructTag;
+      const stakeType = `${address}::${module}::${name}`;
+      const coinName = poolValuesMetadataMap[
+        stakeType
+      ]?.symbol.toLowerCase() as PoolCoinNames;
+      if (!coinName) return;
+
+      // sui -> ssui, usdc -> susdc, ...
+      const spoolName = `s${coinName}` as MarketCoinNames;
+      const { stakes, points, index } = fields;
+      if (!stakedAccounts[spoolName]) {
+        stakedAccounts[spoolName] = [];
+      }
+      stakedAccounts[spoolName]!.push({
+        stakes,
+        points,
+        index,
+      });
+
+      const stakeBalance = BigNumber(stakes);
+      if (lendingAssets[coinName]) {
+        lendingAssets[coinName]!.amount =
+          lendingAssets[coinName]!.amount.plus(stakeBalance);
+      } else {
+        lendingAssets[coinName] = { coinType: stakeType, amount: stakeBalance };
+      }
+    } else if (isSCoin(obj)) {
+      const marketCoinObj = obj.data as ObjectData<CoinStruct>;
+
+      // access underlying asset type from market coin struct
+      // 0x2::coin::Coin<T>
+      const { address, module, name } = parseStructTag(
+        normalizeStructTag(marketCoinObj.type)
+      ).typeParams[0] as StructTag;
+
+      // convert sCoinType to coinType
+      const sCoinType = `${address}::${module}::${name}`;
+      const coinType = sCoinTypeToCoinTypeMap[sCoinType as sCoinTypeValue];
+      if (!coinType) return;
+
+      const coinName = poolValuesMetadataMap[
+        coinType
+      ]?.symbol.toLowerCase() as PoolCoinNames;
+      if (!coinName) return;
+
+      const coinBalance = BigNumber(marketCoinObj.content?.fields.balance ?? 0);
+
+      if (lendingAssets[coinName]) {
+        lendingAssets[coinName]!.amount =
+          lendingAssets[coinName]!.amount.plus(coinBalance);
+      } else {
+        lendingAssets[coinName] = { coinType, amount: coinBalance };
+      }
+    }
+  });
 
   let pendingReward = BigNumber(0);
 
-  for (const spoolCoin of Object.keys(stakedAccount)) {
-    for (const { points, index, stakes } of stakedAccount[spoolCoin]) {
-      if (spoolData[spoolCoin]) {
-        const increasedPointRate = spoolData[spoolCoin].currentPointIndex
-          ? BigNumber(
-              BigNumber(spoolData[spoolCoin].currentPointIndex).minus(index)
-            ).dividedBy(baseIndexRate)
+  MARKET_COIN_NAMES.forEach((marketCoin) => {
+    if (!stakedAccounts[marketCoin]) return;
+
+    stakedAccounts[marketCoin]!.forEach(({ points, index, stakes }) => {
+      if (spoolData[marketCoin]) {
+        const {
+          currentPointIndex,
+          exchangeRateNumerator,
+          exchangeRateDenominator,
+        } = spoolData[marketCoin];
+        const increasedPointRate = currentPointIndex
+          ? BigNumber(BigNumber(currentPointIndex).minus(index)).dividedBy(
+              baseIndexRate
+            )
           : 0;
         pendingReward = pendingReward.plus(
           BigNumber(stakes)
             .multipliedBy(increasedPointRate)
             .plus(points)
-            .multipliedBy(spoolData[spoolCoin].exchangeRateNumerator)
-            .dividedBy(spoolData[spoolCoin].exchangeRateDenominator)
+            .multipliedBy(exchangeRateNumerator)
+            .dividedBy(exchangeRateDenominator)
         );
       }
-    }
-  }
+    });
+  });
 
   const tokenAddresses = Object.values(lendingAssets).map(
     (value) => value.coinType
@@ -255,33 +338,33 @@ const executor: FetcherExecutor = async (owner: string, cache: Cache) => {
     rewardAssets.push({ ...rewardAssetToken });
   }
 
-  for (const [assetName, assetValue] of Object.entries(lendingAssets)) {
-    if (assetValue.amount.isZero()) continue;
+  Object.entries<UserLending>(lendingAssets)
+    .filter(([assetName, assetValue]) => assetValue.amount.isGreaterThan(0) && marketData[assetName])
+    .forEach(([assetName, assetValue]) => {
+      const { supplyInterestRate } = marketData[assetName]!;
+      const addressMove = formatMoveTokenAddress(assetValue.coinType);
+      const tokenPrice = tokenPrices.get(addressMove);
+      const lendingAmount = assetValue.amount
+        .multipliedBy(lendingRate.get(assetName) ?? 0)
+        .shiftedBy(
+          -1 * (pools[assetName as PoolCoinNames]?.metadata?.decimals ?? 0)
+        )
+        .toNumber();
+      const assetToken = tokenPriceToAssetToken(
+        addressMove,
+        lendingAmount,
+        NetworkId.sui,
+        tokenPrice
+      );
 
-    const market = marketData[assetName];
-    if (!market) continue;
-
-    const addressMove = formatMoveTokenAddress(assetValue.coinType);
-    const tokenPrice = tokenPrices.get(addressMove);
-    const lendingAmount = assetValue.amount
-      .multipliedBy(lendingRate.get(assetName) ?? 0)
-      .shiftedBy(-1 * (pools[assetName]?.metadata?.decimals ?? 0))
-      .toNumber();
-    const assetToken = tokenPriceToAssetToken(
-      addressMove,
-      lendingAmount,
-      NetworkId.sui,
-      tokenPrice
-    );
-
-    suppliedYields.push([
-      {
-        apy: aprToApy(market.supplyInterestRate),
-        apr: market.supplyInterestRate,
-      },
-    ]);
-    suppliedAssets.push(assetToken);
-  }
+      suppliedYields.push([
+        {
+          apy: aprToApy(supplyInterestRate),
+          apr: supplyInterestRate,
+        },
+      ]);
+      suppliedAssets.push(assetToken);
+    });
   if (
     suppliedAssets.length === 0 &&
     borrowedAssets.length === 0 &&

--- a/packages/plugins/src/plugins/scallop/marketJob.ts
+++ b/packages/plugins/src/plugins/scallop/marketJob.ts
@@ -20,6 +20,7 @@ import type {
   InterestModelData,
   MarketData,
   MarketJobResult,
+  PoolCoinNames,
   Pools,
 } from './types';
 import runInBatch from '../../utils/misc/runInBatch';
@@ -61,7 +62,7 @@ const executor: JobExecutor = async (cache: Cache) => {
           name: {
             type: '0x1::type_name::TypeName',
             value: {
-              name: pools[coinName].coinType.substring(2),
+              name: pools[coinName as PoolCoinNames].coinType.substring(2),
             },
           },
         })
@@ -83,7 +84,7 @@ const executor: JobExecutor = async (cache: Cache) => {
           name: {
             type: '0x1::type_name::TypeName',
             value: {
-              name: pools[coinName].coinType.substring(2),
+              name: pools[coinName as PoolCoinNames].coinType.substring(2),
             },
           },
         })
@@ -104,7 +105,7 @@ const executor: JobExecutor = async (cache: Cache) => {
         name: {
           type: '0x1::type_name::TypeName',
           value: {
-            name: pools[coinName].coinType.substring(2),
+            name: pools[coinName as PoolCoinNames].coinType.substring(2),
           },
         },
       })
@@ -171,8 +172,8 @@ const executor: JobExecutor = async (cache: Cache) => {
 
     market[asset] = {
       coin: asset,
-      decimal: pools[asset].metadata?.decimals ?? 0,
-      coinType: pools[asset].coinType,
+      decimal: pools[asset as PoolCoinNames].metadata?.decimals ?? 0,
+      coinType: pools[asset as PoolCoinNames].coinType,
       growthInterest: growthInterest.toNumber(),
       borrowInterestRate: Math.min(
         calculatedBorrowRate,

--- a/packages/plugins/src/plugins/scallop/obligationsFetcher.ts
+++ b/packages/plugins/src/plugins/scallop/obligationsFetcher.ts
@@ -242,7 +242,7 @@ const executor: FetcherExecutor = async (owner: string, cache: Cache) => {
       networkId: NetworkId.sui,
       platformId,
       label: 'Lending',
-      name: `${shortenAddress(account, 5, 3)} Obligations`,
+      name: `Obligation ID: ${shortenAddress(account, 5, 3)}`,
       value,
       data: {
         borrowedAssets,

--- a/packages/plugins/src/plugins/scallop/obligationsFetcher.ts
+++ b/packages/plugins/src/plugins/scallop/obligationsFetcher.ts
@@ -15,7 +15,7 @@ import { Cache } from '../../Cache';
 import { Fetcher, FetcherExecutor } from '../../Fetcher';
 import {
   marketKey,
-  obligationKeyPackageId,
+  OBLIGATION_KEY_TYPE,
   platformId,
   poolsKey,
   poolsPrefix,
@@ -53,7 +53,7 @@ const executor: FetcherExecutor = async (owner: string, cache: Cache) => {
   const filterOwnerObject: SuiObjectDataFilter = {
     MatchAny: [
       {
-        StructType: obligationKeyPackageId,
+        StructType: OBLIGATION_KEY_TYPE,
       },
     ],
   };

--- a/packages/plugins/src/plugins/scallop/poolsJob.ts
+++ b/packages/plugins/src/plugins/scallop/poolsJob.ts
@@ -16,7 +16,6 @@ import {
 import { AddressInfo, Coin, PoolCoinNames, Pools, StructTag } from './types';
 import { getObject } from '../../utils/sui/getObject';
 import { getClientSui } from '../../utils/clients';
-import { ObjectData } from '../../utils/sui/types';
 
 const SUI_TYPE = normalizeStructTag(SUI_TYPE_ARG);
 
@@ -52,13 +51,13 @@ const executor: JobExecutor = async (cache: Cache) => {
       const metadataStruct = parseStructTag(
         normalizeStructTag(objectData.type)
       ); // 0x2::coin::CoinMetadata<T>
-      const { address, module, name } = metadataStruct
+      const { address: packageId, module, name } = metadataStruct
         .typeParams[0] as StructTag;
       const objFields = objectData.content?.fields;
       if (!objFields) return;
 
       coinTypes[coinName] = {
-        coinType: `${address}::${module}::${name}`,
+        coinType: `${packageId}::${module}::${name}`,
         metadata: objFields,
       };
     }

--- a/packages/plugins/src/plugins/scallop/poolsJob.ts
+++ b/packages/plugins/src/plugins/scallop/poolsJob.ts
@@ -1,5 +1,9 @@
 import { NetworkId } from '@sonarwatch/portfolio-core';
-import { SUI_TYPE_ARG, normalizeStructTag } from '@mysten/sui.js/utils';
+import {
+  SUI_TYPE_ARG,
+  normalizeStructTag,
+  parseStructTag,
+} from '@mysten/sui.js/utils';
 import { CoinMetadata } from '@mysten/sui.js/client';
 import { Cache } from '../../Cache';
 import { Job, JobExecutor } from '../../Job';
@@ -9,9 +13,10 @@ import {
   poolsKey,
   poolsPrefix as prefix,
 } from './constants';
-import { AddressInfo, Coin, Pools } from './types';
+import { AddressInfo, Coin, PoolCoinNames, Pools, StructTag } from './types';
 import { getObject } from '../../utils/sui/getObject';
 import { getClientSui } from '../../utils/clients';
+import { ObjectData } from '../../utils/sui/types';
 
 const SUI_TYPE = normalizeStructTag(SUI_TYPE_ARG);
 
@@ -23,11 +28,13 @@ const executor: JobExecutor = async (cache: Cache) => {
 
   if (!address) return;
 
-  const coinTypes: Pools = {};
+  const coinTypes: Partial<Pools> = {};
   const coins = new Map<string, Coin>(
     Object.entries(address.mainnet.core.coins)
   );
-  const coinNames: string[] = Array.from(coins.keys());
+  const coinNames: PoolCoinNames[] = Array.from(
+    coins.keys()
+  ) as PoolCoinNames[];
   const client = getClientSui();
   for (const coinName of coinNames) {
     const detail = coins.get(coinName);
@@ -39,14 +46,19 @@ const executor: JobExecutor = async (cache: Cache) => {
       };
     } else {
       const object = await getObject<CoinMetadata>(client, detail.metaData);
-      const objType = normalizeStructTag(object.data?.type || '');
-      const objFields = object.data?.content?.fields;
-      if (!objType || !objFields) return;
+      const objectData = object.data;
+      if (!objectData || !objectData.type) return;
+
+      const metadataStruct = parseStructTag(
+        normalizeStructTag(objectData.type)
+      ); // 0x2::coin::CoinMetadata<T>
+      const { address, module, name } = metadataStruct
+        .typeParams[0] as StructTag;
+      const objFields = objectData.content?.fields;
+      if (!objFields) return;
+
       coinTypes[coinName] = {
-        coinType: objType.substring(
-          objType.indexOf('<') + 1,
-          objType.indexOf('>')
-        ),
+        coinType: `${address}::${module}::${name}`,
         metadata: objFields,
       };
     }

--- a/packages/plugins/src/plugins/scallop/sCoinJob.ts
+++ b/packages/plugins/src/plugins/scallop/sCoinJob.ts
@@ -2,11 +2,10 @@ import { NetworkId } from '@sonarwatch/portfolio-core';
 import { Job, JobExecutor } from '../../Job';
 import {
   scoinKey,
-  sCoinTypesMap,
   scoinPrefix as prefix,
 } from './constants';
 import { Cache } from '../../Cache';
-import { sCoinNames, SCoinTypeMetadata } from './types';
+import { sCoinNames, SCoinTypeMetadata, sCoinTypesMap } from './types';
 import { getClientSui } from '../../utils/clients';
 
 const executor: JobExecutor = async (cache: Cache) => {
@@ -17,7 +16,7 @@ const executor: JobExecutor = async (cache: Cache) => {
       const [coinName, coinType] = curr;
       // eslint-disable-next-line no-param-reassign
       prev[coinName as sCoinNames] = {
-        coinType,
+        coinType: coinType,
         metadata: null,
       };
       return prev;

--- a/packages/plugins/src/plugins/scallop/sCoinJob.ts
+++ b/packages/plugins/src/plugins/scallop/sCoinJob.ts
@@ -4,10 +4,9 @@ import {
   scoinKey,
   sCoinTypesMap,
   scoinPrefix as prefix,
-  sCoinNames,
 } from './constants';
 import { Cache } from '../../Cache';
-import { SCoinTypeMetadata } from './types';
+import { sCoinNames, SCoinTypeMetadata } from './types';
 import { getClientSui } from '../../utils/clients';
 
 const executor: JobExecutor = async (cache: Cache) => {

--- a/packages/plugins/src/plugins/scallop/sCoinJob.ts
+++ b/packages/plugins/src/plugins/scallop/sCoinJob.ts
@@ -16,7 +16,7 @@ const executor: JobExecutor = async (cache: Cache) => {
       const [coinName, coinType] = curr;
       // eslint-disable-next-line no-param-reassign
       prev[coinName as sCoinNames] = {
-        coinType: coinType,
+        coinType,
         metadata: null,
       };
       return prev;

--- a/packages/plugins/src/plugins/scallop/types/address.ts
+++ b/packages/plugins/src/plugins/scallop/types/address.ts
@@ -27,6 +27,7 @@ export interface Core {
   coins: Map<string, Coin>;
   oracles: Oracle;
   packages: Map<string, Package>;
+  object: string;
 }
 
 export interface Coin {

--- a/packages/plugins/src/plugins/scallop/types/basic.ts
+++ b/packages/plugins/src/plugins/scallop/types/basic.ts
@@ -26,3 +26,8 @@ export type WitTable = {
     with_keys: boolean;
   };
 };
+
+export type ExtendedBasicField<T> = {
+  type: string;
+  fields: T;
+}

--- a/packages/plugins/src/plugins/scallop/types/coin.ts
+++ b/packages/plugins/src/plugins/scallop/types/coin.ts
@@ -1,18 +1,49 @@
 import { CoinMetadata } from '@mysten/sui.js/client';
-import { CoinNames, MARKET_COIN_NAMES } from '../constants';
-
-export const SUPPORTED_SPOOL_COIN_NAMES = ['ssui', 'susdc'] as const;
+import { COIN_NAMES, MARKET_COIN_NAMES, SCOIN_NAMES, sCoinTypesMap } from '../constants';
 
 export type MarketCoinNames = (typeof MARKET_COIN_NAMES)[number];
-export type SupportedSpoolCoinNames =
-  (typeof SUPPORTED_SPOOL_COIN_NAMES)[number];
-
-export type AllCoinNames = CoinNames | MarketCoinNames;
-export type UserCoinBalance = {
-  [k in AllCoinNames]?: string;
-};
+export type PoolCoinNames = (typeof COIN_NAMES)[number];
+export type sCoinNames = (typeof SCOIN_NAMES)[number];
+export type AllCoinNames = PoolCoinNames | MarketCoinNames;
 
 export type CoinTypeMetadata = {
   coinType: string;
   metadata: CoinMetadata | null;
 };
+
+export type sCoinToCoinNameType = {[T in sCoinNames]: PoolCoinNames}
+
+export const sCoinToCoinName: sCoinToCoinNameType = {
+  scallop_sui: 'sui',
+  scallop_cetus: 'cetus',
+  scallop_sca: 'sca',
+  scallop_wormhole_usdc: 'usdc',
+  scallop_wormhole_usdt: 'usdt',
+  scallop_wormhole_eth: 'eth',
+  scallop_af_sui: 'afsui',
+  scallop_ha_sui: 'hasui',
+  scallop_v_sui: 'vsui',
+};
+
+export type sCoinTypeValue = (typeof sCoinTypesMap)[sCoinNames];
+
+export const sCoinTypeToCoinTypeMap: { [T in sCoinTypeValue]: string } = {
+  [sCoinTypesMap.scallop_sui]:
+    '0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI',
+  [sCoinTypesMap.scallop_cetus]:
+    '0x06864a6f921804860930db6ddbe2e16acdf8504495ea7481637a1c8b9a8fe54b::cetus::CETUS',
+  [sCoinTypesMap.scallop_sca]:
+    '0x7016aae72cfc67f2fadf55769c0a7dd54291a583b63051a5ed71081cce836ac6::sca::SCA',
+  [sCoinTypesMap.scallop_wormhole_usdc]:
+    '0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN',
+  [sCoinTypesMap.scallop_wormhole_usdt]:
+    '0xc060006111016b8a020ad5b33834984a437aaa7d3c74c18e09a95d48aceab08c::coin::COIN',
+  [sCoinTypesMap.scallop_wormhole_eth]:
+    '0xaf8cd5edc19c4512f4259f0bee101a40d41ebed738ade5874359610ef8eeced5::coin::COIN',
+  [sCoinTypesMap.scallop_af_sui]:
+    '0xf325ce1300e8dac124071d3152c5c5ee6174914f8bc2161e88329cf579246efc::afsui::AFSUI',
+  [sCoinTypesMap.scallop_ha_sui]:
+    '0xbde4ba4c2e274a60ce15c1cfff9e5c42e41654ac8b6d906a57efa4bd3c29f47d::hasui::HASUI',
+  [sCoinTypesMap.scallop_v_sui]:
+    '0x549e8b69270defbfafd4f94e17ec44cdbdd99820b33bda2278dea3b9a32d3f55::cert::CERT',
+} as const;

--- a/packages/plugins/src/plugins/scallop/types/coin.ts
+++ b/packages/plugins/src/plugins/scallop/types/coin.ts
@@ -1,17 +1,17 @@
 import { CoinMetadata } from '@mysten/sui.js/client';
-import { COIN_NAMES, MARKET_COIN_NAMES, SCOIN_NAMES, sCoinTypesMap } from '../constants';
+import { COIN_NAMES, MARKET_COIN_NAMES, SCOIN_NAMES } from '../constants';
 
 export type MarketCoinNames = (typeof MARKET_COIN_NAMES)[number];
 export type PoolCoinNames = (typeof COIN_NAMES)[number];
 export type sCoinNames = (typeof SCOIN_NAMES)[number];
-export type AllCoinNames = PoolCoinNames | MarketCoinNames;
 
 export type CoinTypeMetadata = {
   coinType: string;
   metadata: CoinMetadata | null;
 };
 
-export type sCoinToCoinNameType = {[T in sCoinNames]: PoolCoinNames}
+type sCoinToCoinNameType = { [T in sCoinNames]: PoolCoinNames };
+type sCoinTypesMapType = { [T in sCoinNames]: string };
 
 export const sCoinToCoinName: sCoinToCoinNameType = {
   scallop_sui: 'sui',
@@ -24,6 +24,27 @@ export const sCoinToCoinName: sCoinToCoinNameType = {
   scallop_ha_sui: 'hasui',
   scallop_v_sui: 'vsui',
 };
+
+export const sCoinTypesMap: sCoinTypesMapType = {
+  scallop_sui:
+    '0xaafc4f740de0dd0dde642a31148fb94517087052f19afb0f7bed1dc41a50c77b::scallop_sui::SCALLOP_SUI',
+  scallop_cetus:
+    '0xea346ce428f91ab007210443efcea5f5cdbbb3aae7e9affc0ca93f9203c31f0c::scallop_cetus::SCALLOP_CETUS',
+  scallop_sca:
+    '0x5ca17430c1d046fae9edeaa8fd76c7b4193a00d764a0ecfa9418d733ad27bc1e::scallop_sca::SCALLOP_SCA',
+  scallop_wormhole_usdc:
+    '0xad4d71551d31092230db1fd482008ea42867dbf27b286e9c70a79d2a6191d58d::scallop_wormhole_usdc::SCALLOP_WORMHOLE_USDC',
+  scallop_wormhole_usdt:
+    '0xe6e5a012ec20a49a3d1d57bd2b67140b96cd4d3400b9d79e541f7bdbab661f95::scallop_wormhole_usdt::SCALLOP_WORMHOLE_USDT',
+  scallop_wormhole_eth:
+    '0x67540ceb850d418679e69f1fb6b2093d6df78a2a699ffc733f7646096d552e9b::scallop_wormhole_eth::SCALLOP_WORMHOLE_ETH',
+  scallop_af_sui:
+    '0x00671b1fa2a124f5be8bdae8b91ee711462c5d9e31bda232e70fd9607b523c88::scallop_af_sui::SCALLOP_AF_SUI',
+  scallop_ha_sui:
+    '0x9a2376943f7d22f88087c259c5889925f332ca4347e669dc37d54c2bf651af3c::scallop_ha_sui::SCALLOP_HA_SUI',
+  scallop_v_sui:
+    '0xe1a1cc6bcf0001a015eab84bcc6713393ce20535f55b8b6f35c142e057a25fbe::scallop_v_sui::SCALLOP_V_SUI',
+} as const;
 
 export type sCoinTypeValue = (typeof sCoinTypesMap)[sCoinNames];
 

--- a/packages/plugins/src/plugins/scallop/types/data.ts
+++ b/packages/plugins/src/plugins/scallop/types/data.ts
@@ -1,6 +1,10 @@
 import BigNumber from 'bignumber.js';
-import { CoinTypeMetadata } from './coin';
-import { sCoinNames } from '../constants';
+import {
+  CoinTypeMetadata,
+  MarketCoinNames,
+  PoolCoinNames,
+  sCoinNames,
+} from './coin';
 
 export type UserLending = {
   coinType: string;
@@ -14,12 +18,16 @@ export type UserObligations = {
   };
 };
 
+export type UserLendingData = {
+  [T in PoolCoinNames]?: UserLending;
+};
+
 export type UserStakeAccounts = {
-  [T in string]: { points: string; index: string; stakes: string }[];
+  [T in MarketCoinNames]?: { points: string; index: string; stakes: string }[];
 };
 
 export type Pools = {
-  [T in string]: CoinTypeMetadata;
+  [T in PoolCoinNames]: CoinTypeMetadata;
 };
 
 export type SCoinTypeMetadata = {

--- a/packages/plugins/src/plugins/scallop/types/index.ts
+++ b/packages/plugins/src/plugins/scallop/types/index.ts
@@ -3,3 +3,5 @@ export * from './coin';
 export * from './market';
 export * from './data';
 export * from './basic';
+export * from './spool';
+export * from './sui';

--- a/packages/plugins/src/plugins/scallop/types/spool.ts
+++ b/packages/plugins/src/plugins/scallop/types/spool.ts
@@ -1,0 +1,11 @@
+import { ExtendedBasicField, IdField, NameField } from './basic';
+
+export type SpoolAccountFieldsType = {
+  id: IdField;
+  index: string;
+  points: string;
+  spool_id: string;
+  stake_type: ExtendedBasicField<NameField>;
+  stakes: string;
+  total_points: string;
+};

--- a/packages/plugins/src/plugins/scallop/types/sui.ts
+++ b/packages/plugins/src/plugins/scallop/types/sui.ts
@@ -1,0 +1,3 @@
+import { parseStructTag } from "@mysten/sui.js/utils";
+
+export type StructTag = ReturnType<typeof parseStructTag>;

--- a/packages/plugins/src/plugins/scallop/types/vesca.ts
+++ b/packages/plugins/src/plugins/scallop/types/vesca.ts
@@ -1,10 +1,10 @@
+import { ExtendedBasicField, IdField, NameField } from "./basic";
+
+type VeScaValueType = {
+  locked_sca_amount: string;
+  unlock_at: string;
+} 
 export type VeSca = {
-  id: {
-    id: string;
-  };
-  name: string;
-  value: {
-    type: string;
-    fields: { locked_sca_amount: string; unlock_at: string };
-  };
-};
+  id: IdField,
+  value: ExtendedBasicField<VeScaValueType>;
+} & NameField;

--- a/packages/plugins/src/plugins/scallop/veScaFetcher.ts
+++ b/packages/plugins/src/plugins/scallop/veScaFetcher.ts
@@ -7,7 +7,7 @@ import {
 import BigNumber from 'bignumber.js';
 import { Cache } from '../../Cache';
 import { Fetcher, FetcherExecutor } from '../../Fetcher';
-import { platformId, scaAddress, scaDecimals, veScaKeyType } from './constants';
+import { platformId, scaAddress, scaDecimals, VE_SCA_KEY_TYPE } from './constants';
 import tokenPriceToAssetToken from '../../utils/misc/tokenPriceToAssetToken';
 import { getOwnedObjects } from '../../utils/sui/getOwnedObjects';
 import { multiDynamicFieldObjects } from '../../utils/sui/multiDynamicFieldObjects';
@@ -18,7 +18,7 @@ const executor: FetcherExecutor = async (owner: string, cache: Cache) => {
   const client = getClientSui();
   const veScaKeys = await getOwnedObjects(client, owner, {
     filter: {
-      StructType: veScaKeyType,
+      StructType: VE_SCA_KEY_TYPE,
     },
   });
   if (veScaKeys.length === 0) return [];

--- a/packages/plugins/src/plugins/scallop/veScaFetcher.ts
+++ b/packages/plugins/src/plugins/scallop/veScaFetcher.ts
@@ -7,7 +7,7 @@ import {
 import BigNumber from 'bignumber.js';
 import { Cache } from '../../Cache';
 import { Fetcher, FetcherExecutor } from '../../Fetcher';
-import { platformId, scaAddress, scaDecimals } from './constants';
+import { platformId, scaAddress, scaDecimals, veScaKeyType } from './constants';
 import tokenPriceToAssetToken from '../../utils/misc/tokenPriceToAssetToken';
 import { getOwnedObjects } from '../../utils/sui/getOwnedObjects';
 import { multiDynamicFieldObjects } from '../../utils/sui/multiDynamicFieldObjects';
@@ -18,8 +18,7 @@ const executor: FetcherExecutor = async (owner: string, cache: Cache) => {
   const client = getClientSui();
   const veScaKeys = await getOwnedObjects(client, owner, {
     filter: {
-      StructType:
-        '0xcfe2d87aa5712b67cad2732edb6a2201bfdf592377e5c0968b7cb02099bd8e21::ve_sca::VeScaKey',
+      StructType: veScaKeyType,
     },
   });
   if (veScaKeys.length === 0) return [];


### PR DESCRIPTION
This PR fix the issue where the user unstaked LSD (sSui, sUsdc, etc) is not detected as lending in Sonarwatch.
This PR also fix some types and improve the code readability

### TESTING
- To test this project, run `npx nx run plugins:serve-cache` first.
- Then in another terminal, run
`npx nx run plugins:run-job scallop-address && npx nx run plugins:run-job scallop-market && npx nx run plugins:run-job scallop-pools && npx nx run plugins:run-job scallop-spoolsmarket && npx nx run plugins:run-job scallop-scoin && npx nx run plugins:run-fetcher [FETCHER_TYPE] \'[YOUR_WALLET_ADDRESS]\'`

### Example: 
`npx nx run plugins:run-job scallop-address && npx nx run plugins:run-job scallop-market && npx nx run plugins:run-job scallop-pools && npx nx run plugins:run-job scallop-spoolsmarket && npx nx run plugins:run-job scallop-scoin && npx nx run plugins:run-fetcher scallop-lendings \'0x61819c99588108d9f7710047e6ad8f2da598de8e98a26ea62bd7ad9847f5329c\'` to get lendings of the wallet address